### PR TITLE
Enhance vertex positioning to avoid overlapping

### DIFF
--- a/isomorphism.html
+++ b/isomorphism.html
@@ -141,6 +141,69 @@ canvas {
 <script src="graf.js"></script>
 <script src="isomorphism.js"></script>
 <script type="text/javascript">
+// from: https://github.com/mattdesl/point-circle-collision
+var tmp = [0,0]
+function pointCircleCollide(point, circle, r) {
+    if (r===0) return false
+    var dx = circle[0] - point[0]
+    var dy = circle[1] - point[1]
+    return dx * dx + dy * dy <= r * r
+}
+// from: https://github.com/mattdesl/line-circle-collision
+function lineCircleCollide(a, b, circle, radius, nearest) {
+    //check to see if start or end points lie within circle 
+    if (pointCircleCollide(a, circle, radius)) {
+        if (nearest) {
+            nearest[0] = a[0]
+            nearest[1] = a[1]
+        }
+        return true
+    } if (pointCircleCollide(b, circle, radius)) {
+        if (nearest) {
+            nearest[0] = b[0]
+            nearest[1] = b[1]
+        }
+        return true
+    }
+    
+    var x1 = a[0],
+        y1 = a[1],
+        x2 = b[0],
+        y2 = b[1],
+        cx = circle[0],
+        cy = circle[1]
+
+    //vector d
+    var dx = x2 - x1
+    var dy = y2 - y1
+    
+    //vector lc
+    var lcx = cx - x1
+    var lcy = cy - y1
+    
+    //project lc onto d, resulting in vector p
+    var dLen2 = dx * dx + dy * dy //len2 of d
+    var px = dx
+    var py = dy
+    if (dLen2 > 0) {
+        var dp = (lcx * dx + lcy * dy) / dLen2
+        px *= dp
+        py *= dp
+    }
+    
+    if (!nearest)
+        nearest = tmp
+    nearest[0] = x1 + px
+    nearest[1] = y1 + py
+    
+    //len2 of p
+    var pLen2 = px * px + py * py
+    
+    //check collision
+    return pointCircleCollide(nearest, circle, radius)
+            && pLen2 <= dLen2 && (px * dx + py * dy) >= 0
+}
+
 var n, round = 0, g, g2, gvm, gvm2, cgv, cgv2, answer, worker;
 var startTime;
 var schedule = [
@@ -284,24 +347,78 @@ function removeRandomEdge(g) {
 	}
 }
 function randomizePositions(gvm) {
-	for (var i = 0; i < gvm.v.length; i++) {
-		//try to place randomly in a clear space, up to 1000 times
-		var p;
-		for (var j = 0; j < 1000; j++) {
-			var tryRandomPosition = function() {
-				p = [Math.random() * 4 - 2, Math.random() * 4 - 2]; 
+
+	for(var tries = 0; tries < 10; tries++) {
+
+		var fixSuccess = true
+		var minCircleDistance = .51
+		var minLineDistance = .3
+		for (var i = 0; i < gvm.v.length; i++) {
+			//try to place randomly in a clear space, up to 1000 times
+			var p
+			var isHittingLine = false
+			checkPosition: for (var j = 0; j < 1000; j++) {
+				p = [Math.random() * 4 - 2, Math.random() * 4 - 2]
+				gvm.v[i].p = p
+				isHittingLine = false
+
+				// check cirlce collisions
 				for (var k = 0; k < i; k++) {
-					if (Math.abs(gvm.v[k].p[0] - p[0]) < .4 || Math.abs(gvm.v[k].p[1] - p[1]) < .4) {
-						return false;
+					if (Math.abs(gvm.v[k].p[0] - p[0]) < minCircleDistance && Math.abs(gvm.v[k].p[1] - p[1]) < minCircleDistance) {
+						isHittingLine = true
+						continue checkPosition
 					}
 				}
-				return true;
-			};
-			if (tryRandomPosition()) {
-				break;
+
+				// check new circle does not hit existing lines
+				var lines = gvm.e
+					.filter(e => e.e[0] !== i && e.e[1] !== i)
+					.map(e => [gvm.v[e.e[0]].p, gvm.v[e.e[1]].p ])
+				
+				for(var k = 0; k < lines.length; k++) {
+					if(lineCircleCollide(lines[k][0],lines[k][1],p, minLineDistance)) {
+						isHittingLine = true
+						continue checkPosition
+					}
+				}
+				
+				// all edges connected to current circle i
+				var newEdges = gvm.e.filter(e => e.e[0] === i || e.e[1] === i)//
+				// all lines (2 points) based of those edges
+				var newLines = newEdges.map(e => {
+					return [
+						e.e[0] === i ? p : gvm.v[e.e[0]].p,
+						e.e[1] === i ? p : gvm.v[e.e[1]].p
+					]
+				})
+				
+				for(var k = 0; k < newLines.length; k++) {
+					var irrelevantVertexIDs = [newEdges[k].e[0], newEdges[k].e[1]]
+
+					var relevantVertices = gvm.v
+						.map((a,b) => b)
+						.filter((a,id) => irrelevantVertexIDs.indexOf(id) === -1)
+
+					for(var u = 0; u < relevantVertices.length; u++) {
+						if(lineCircleCollide(newLines[k][0],newLines[k][1], gvm.v[relevantVertices[u]].p, minLineDistance)) {
+							isHittingLine = true
+							continue checkPosition
+						}
+					}
+				}
+
+				if(!isHittingLine) {
+					break checkPosition
+				}
+			}
+			if(isHittingLine) {
+				fixSuccess = false
 			}
 		}
-		gvm.v[i].p = p;
+
+		if(fixSuccess) {
+			break
+		}
 	}
 }
 function onLoad() {


### PR DESCRIPTION
The circles in the isomorphism game are overlapping edges which they are not connected to. This makes the game hard to play esp. on mobile devices.

I changed the `randomizePositions` method to prevent a) circles to be placed on previously placed edges and b) prevent edges from a newly placed circle to overlap other circles/vertices.

The `lineCircleCollide` function was taken from [https://github.com/mattdesl/line-circle-collision](https://github.com/mattdesl/line-circle-collision). I think copy/pasting it to this demo is easiest for now rather than integrating e.g. browserify or some other build process..